### PR TITLE
Update image platform settings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -133,7 +133,7 @@ tasks.register('buildDocker', Exec) {
     group "Docker"
     inputs.dir(layout.buildDirectory.dir("docker"))
     workingDir layout.buildDirectory.dir("docker")
-    commandLine "docker", "buildx", "build", "--platform", "linux/arm64,linux/amd64,linux/arm/v7",
+    commandLine "docker", "buildx", "build", "--platform", "linux/arm64,linux/amd64",
             "--pull", "-t", "nagyesta/assumed-identity:${project.version}", "."
     dependsOn(":createDockerBuildx")
 }
@@ -142,7 +142,7 @@ tasks.register('buildDockerPush', Exec) {
     group "Docker"
     inputs.dir(layout.buildDirectory.dir("docker"))
     workingDir layout.buildDirectory.dir("docker")
-    commandLine "docker", "buildx", "build", "--platform", "linux/arm64,linux/amd64,linux/arm/v7",
+    commandLine "docker", "buildx", "build", "--platform", "linux/arm64,linux/amd64",
             "--push", "-t", "nagyesta/assumed-identity:${project.version}", "."
 }
 


### PR DESCRIPTION
__Issue:__ N/A <!-- #issue number -->

### Description
<!-- A short summary of changes -->

- Reduces the build platforms to linux/arm64 and linux/amd64 to simplify maintenance and support the same platforms as Lowkey Vauld multiarch images

### Entry point
<!-- Where should the reviewer start in order to properly understand the PR? -->

-

### Checklists

- [x] I have rebased my branch
- [x] My commit message is meaningful
- [x] The changes are focusing on the issue at hand

### Notes

-
<!-- Any additional remarks you may have. -->
