### PR TITLE
feat: add ssl support with self-signed certificate

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,12 +64,16 @@ implementation. These are specifically mentioned in the Lowkey Vault examples
 
 You can pass environmental variables with the following names and functions to alter Assumed Identity configuration
 
-| Name                | Default                                                       | Description                                                                                                    |
-|---------------------|---------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------|
-| ASSUMED_ID_PORT     | 80                                                            | The port where Assumed Identity will listen to requests.                                                       |
-| ASSUMED_ID_HOST     | 0.0.0.0                                                       | The host/IP Assumed Identity will use to listen to requests. 0.0.0.0 means any.                                |
-| ASSUMED_ID_ISSUER   | https://sts.windows.net/00000000-0000-0000-0000-000000000000/ | The name of the issuer used in the tokens                                                                      |
-| ASSUMED_ID_KEY_PATH | \<use random generated key>                                   | The path where the RSA key file is mounted (inside the container) that needs to be used for signing the tokens | 
+| Name                                | Default                                                       | Description                                                                                                    |
+|-------------------------------------|---------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------|
+| ASSUMED_ID_PORT                     | 80                                                            | The port where Assumed Identity will listen to requests.                                                       |
+| ASSUMED_ID_HOST                     | 0.0.0.0                                                       | The host/IP Assumed Identity will use to listen to requests. 0.0.0.0 means any.                                |
+| ASSUMED_ID_ISSUER                   | https://sts.windows.net/00000000-0000-0000-0000-000000000000/ | The name of the issuer used in the tokens                                                                      |
+| ASSUMED_ID_KEY_PATH                 | \<use random generated key>                                   | The path where the RSA key file is mounted (inside the container) that needs to be used for signing the tokens | 
+| ASSUMED_ID_SSL_CERTIFICATE_PATH     | \<disabled>                                                   | The path where the SSL certificate file is mounted (inside the container)                                      |
+| ASSUMED_ID_SSL_CERTIFICATE_KEY_PATH | \<disabled>                                                   | The path where the SSL certificate key file is mounted (inside the container)                                  |
+
+When `ASSUMED_ID_SSL_CERTIFICATE_PATH` is set, Assumed Identity serves requests over HTTPS.
 
 ### All endpoints
 

--- a/src/python/app.py
+++ b/src/python/app.py
@@ -1,6 +1,7 @@
 import json
 import os
 import re
+import ssl
 import time
 from argparse import Namespace, ArgumentParser
 from re import Pattern
@@ -57,6 +58,16 @@ def import_key(key_path: str) -> RSAKey:
     return key
 
 
+def init_ssl_context(ssl_certificate_path: str | None, ssl_certificate_key_path: str | None) -> ssl.SSLContext | None:
+    if ssl_certificate_path is None:
+        if ssl_certificate_key_path is not None:
+            raise ValueError("SSL certificate key path can only be used together with SSL certificate path")
+        return None
+    context = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
+    context.load_cert_chain(certfile=ssl_certificate_path, keyfile=ssl_certificate_key_path)
+    return context
+
+
 url_regexp = ('^(http(s)?)://'
               '('
               '(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}'
@@ -110,6 +121,8 @@ def process_arguments() -> Namespace:
     parser.add_argument("--key-path", help="The path to the key you want to use", type=str)
     parser.add_argument("--port", help="The port number you want to use", type=int,
                         default=5000)
+    parser.add_argument("--ssl-certificate-path", help="The path to the SSL certificate you want to use", type=str)
+    parser.add_argument("--ssl-certificate-key-path", help="The path to the SSL certificate key you want to use", type=str)
     return parser.parse_args()
 
 
@@ -118,8 +131,10 @@ if __name__ == '__main__':
 
     issuer = os.getenv("ASSUMED_ID_ISSUER") if os.getenv("ASSUMED_ID_ISSUER") else args.issuer
     key_path = os.getenv("ASSUMED_ID_KEY_PATH") if os.getenv("ASSUMED_ID_KEY_PATH") else args.key_path
+    cert_path = os.getenv("ASSUMED_ID_SSL_CERTIFICATE_PATH") if os.getenv("ASSUMED_ID_SSL_CERTIFICATE_PATH") else args.ssl_certificate_path
+    cert_key_path = os.getenv("ASSUMED_ID_SSL_CERTIFICATE_KEY_PATH") if os.getenv("ASSUMED_ID_SSL_CERTIFICATE_KEY_PATH") else args.ssl_certificate_key_path
     app.config.update({
         "AID_ISSUER": issuer,
         "AID_KEY": init_key(key_path)
     })
-    app.run(args.host, args.port)
+    app.run(args.host, args.port, ssl_context=init_ssl_context(cert_path, cert_key_path))

--- a/src/python/test.py
+++ b/src/python/test.py
@@ -1,5 +1,7 @@
+import sys
 import time
 import unittest
+import unittest.mock
 import pytest
 
 import app
@@ -15,6 +17,40 @@ def test_client():
 
 
 class AppTestCase(unittest.TestCase):
+    def test_process_arguments_should_parse_ssl_certificate_parameters(self):
+        # when
+        with unittest.mock.patch.object(sys, "argv", ["app.py", "--ssl-certificate-path", "certificate.pem", "--ssl-certificate-key-path", "key.pem"]):
+            actual = app.process_arguments()
+
+        # then
+        self.assertEqual("certificate.pem", actual.ssl_certificate_path, "SSL certificate path should have been parsed")
+        self.assertEqual("key.pem", actual.ssl_certificate_key_path, "SSL certificate key path should have been parsed")
+
+    def test_init_ssl_context_should_return_none_when_ssl_certificate_is_not_provided(self):
+        # when
+        actual = app.init_ssl_context(None, None)
+
+        # then
+        self.assertIsNone(actual, "SSL context should be None when no SSL certificate is provided")
+
+    def test_init_ssl_context_should_raise_error_when_ssl_certificate_key_is_provided_without_ssl_certificate(self):
+        # when / then
+        with self.assertRaisesRegex(ValueError, "SSL certificate key path can only be used together with SSL certificate path"):
+            app.init_ssl_context(None, "key.pem")
+
+    def test_init_ssl_context_should_load_ssl_certificate_chain_when_ssl_certificate_is_provided(self):
+        # given
+        expected_context = unittest.mock.MagicMock()
+
+        # when
+        with unittest.mock.patch("app.ssl.SSLContext", return_value=expected_context) as ssl_context_constructor:
+            actual = app.init_ssl_context("certificate.pem", "key.pem")
+
+        # then
+        ssl_context_constructor.assert_called_once_with(app.ssl.PROTOCOL_TLS_SERVER)
+        expected_context.load_cert_chain.assert_called_once_with(certfile="certificate.pem", keyfile="key.pem")
+        self.assertEqual(expected_context, actual, "Returned SSL context should have been the initialized context")
+
     def test_token_endpoint_json_should_contain_expected_Fields_when_called_with_valid_url(self):
         # given
         resource: str = "https://localhost:8443"


### PR DESCRIPTION
**Issue:** N/A <!-- #issue number -->

### Description

- Introduced `--ssl-certificate-path` and `--ssl-certificate-key-path` arguments.
- Added support for initializing an SSL context.
- Updated application to serve requests over HTTPS when SSL configuration is provided.
- Enhanced tests to cover new SSL functionality.
- Updated README with SSL configuration details.

### Entry point

<!-- Where should the reviewer start in order to properly understand the PR? -->

- ./src/python/app.py

### Checklists

- [x] I have rebased my branch
- [x] My commit message is meaningful
- [x] The changes are focusing on the issue at hand

### Notes

https://github.com/Azure/azure-sdk-for-net/blob/6030161d369e0abb43ef8e3085b2632d0869bb34/sdk/identity/Azure.Identity/src/Credentials/TokenCredentialOptions.cs#L26-L33

https://github.com/Azure/azure-sdk-for-net/blob/ba9a25f0aa1ab7fff7dcbe1691ebb61c068df77e/sdk/core/Azure.Core/src/Identity/Validations.cs#L49-L60